### PR TITLE
Fix error when using Windows.

### DIFF
--- a/scheduler.asd
+++ b/scheduler.asd
@@ -1,4 +1,3 @@
-
 (asdf:defsystem #:scheduler
   :name "scheduler"
   :author "Park Sungmin. byulparan@icloud.com"
@@ -7,7 +6,7 @@
   :depends-on (#:bordeaux-threads #:pileup #:cffi #+ecl #:bt-semaphore)
   :serial t
   :components ((:file "package") 
-	       #+windows (:file "threads-windows")
-	       #-windows (:file "threads-posix")
+	       (:file #-(or win32 windows mswindows) "threads-posix"
+		      #+(or win32 windows mswindows) "threads-windows")
 	       (:file "time")
-	       (:file "scheduler"))) 
+	       (:file "scheduler")))

--- a/threads-windows.lisp
+++ b/threads-windows.lisp
@@ -1,6 +1,6 @@
 (in-package :scheduler)
 
-(defun set-real-time-thread-priority ()
+(defun set-thread-realtime-priority ()
   "Not implements windows,yet"
   (values))
 


### PR DESCRIPTION
Typo in function name. Safer system definition (for some reason it
wasn't detecting the :windows feature keyword in my win machine).

Thread priority remains not implemented.